### PR TITLE
Removing deprecation warning

### DIFF
--- a/lib/word_salad/core_ext.rb
+++ b/lib/word_salad/core_ext.rb
@@ -1,5 +1,4 @@
-class Fixnum
-
+class Integer
   # Returns +num+ random words from the dictionary.
   def words
     dict = WordSalad.dictionary
@@ -42,6 +41,4 @@ class Fixnum
   def paragraph(psize=5, ssize=10)
     1.paragraphs(psize, ssize).first
   end
-
 end
-


### PR DESCRIPTION
Fixnum [has been deprecated](https://bugs.ruby-lang.org/issues/12005) in ruby 2.4, so changing it to remove warning.